### PR TITLE
Single-node control plane + scheduled etcd backups

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "includeCoAuthoredBy": false
+}

--- a/applications/operators/etcd-backup/README.md
+++ b/applications/operators/etcd-backup/README.md
@@ -1,0 +1,56 @@
+# etcd-backup
+
+Scheduled etcd snapshots for the single-node control plane. With one etcd
+member there is no quorum to fall back on, so an off-node backup is the only
+recovery path if the control-plane node or its disk is lost.
+
+## How it works
+
+[`talos-backup`](https://github.com/siderolabs/talos-backup) runs as a CronJob
+(every 6 hours). It calls the Talos API for a consistent etcd snapshot,
+age-encrypts it, and pushes it to an S3 bucket.
+
+- **Auth** — a `talos.dev` `ServiceAccount` (`talos-etcd-backup`) scoped to the
+  `os:etcd:backup` role. Talos materialises a Secret the pod mounts at
+  `/var/run/secrets/talos.dev`. This requires
+  `machine.features.kubernetesTalosAPIAccess` on the control plane, which is
+  set in Terraform (`terragrunt/cluster/talos/main.tf`) and gated to this
+  namespace and role.
+- **Storage** — an `ObjectBucketClaim` (`ceph-bucket` class) provisions a
+  bucket on the Ceph object store. Rook drops a ConfigMap + Secret named
+  `etcd-backup` with the bucket name and access keys, which the CronJob reads.
+  The bucket lives on the Ceph OSDs on the **Proxmox** tier — a different
+  failure domain from the Hetzner control plane, so losing the CP node does
+  not lose its backups.
+- **Encryption** — snapshots are encrypted to the `AGE_RECIPIENT_PUBLIC_KEY`
+  in `manifests/cronjob.yaml` (currently the YubiKey identity from
+  `.sops.yaml`). You need the matching private key to restore.
+
+## Before this works
+
+1. Apply the Terraform change so `kubernetesTalosAPIAccess` is live on the
+   control plane (the `serviceaccounts.talos.dev` CRD appears once it is).
+2. Pin the container image — `manifests/cronjob.yaml` uses `:latest`; replace
+   it with a released tag from `ghcr.io/siderolabs/talos-backup`.
+3. Confirm the age recipient is a key you actually hold offline.
+
+## Restore
+
+```sh
+# 1. Pull the newest snapshot from the bucket (mc/aws/rclone against the RGW).
+# 2. Decrypt it:
+age -d -i <your-age-identity> -o db.snapshot <snapshot>.age
+# 3. Recover the control plane from it:
+talosctl bootstrap --recover-from=./db.snapshot
+```
+
+See the Talos [disaster recovery guide](https://www.talos.dev/latest/advanced/disaster-recovery/)
+for the full procedure.
+
+## Caveat
+
+The bucket is in-cluster (Ceph). This covers the likely failures — control-plane
+node/disk loss or etcd corruption while the rest of the cluster survives. It
+does **not** cover total-cluster loss; for that, replicate the bucket off-site
+(talos-backup can target any S3 endpoint, so a second CronJob or bucket
+replication to external object storage is the follow-up).

--- a/applications/operators/etcd-backup/argo-app.yaml
+++ b/applications/operators/etcd-backup/argo-app.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: etcd-backup
+  namespace: argocd
+spec:
+  project: platform
+  source:
+    path: applications/operators/etcd-backup/manifests
+    repoURL: https://github.com/tiborpilz/infrastructure
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: etcd-backup
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
+      - CreateNamespace=false

--- a/applications/operators/etcd-backup/kustomization.yaml
+++ b/applications/operators/etcd-backup/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - argo-app.yaml

--- a/applications/operators/etcd-backup/manifests/cronjob.yaml
+++ b/applications/operators/etcd-backup/manifests/cronjob.yaml
@@ -1,0 +1,86 @@
+# Takes an etcd snapshot every 6 hours via the Talos API and pushes it to the
+# Ceph object store, age-encrypted. Auth comes from the mounted talos.dev
+# ServiceAccount secret; S3 creds/bucket come from the ObjectBucketClaim.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: etcd-backup
+  namespace: etcd-backup
+spec:
+  schedule: "17 */6 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: talos-backup
+              # TODO: pin to a released tag from
+              # ghcr.io/siderolabs/talos-backup once confirmed.
+              image: ghcr.io/siderolabs/talos-backup:latest
+              env:
+                - name: CLUSTER_NAME
+                  value: hcloud-poc
+                - name: CUSTOM_S3_ENDPOINT
+                  value: http://rook-ceph-rgw-ceph-objectstore.rook-ceph.svc:80
+                - name: AWS_REGION
+                  value: us-east-1
+                - name: USE_PATH_STYLE
+                  value: "true"
+                - name: ENABLE_COMPRESSION
+                  value: "true"
+                - name: S3_PREFIX
+                  value: etcd
+                # age recipient used to encrypt each snapshot. This is the
+                # YubiKey identity from .sops.yaml — restoring a backup needs
+                # that key. Swap for whichever offline key you want to hold.
+                - name: AGE_RECIPIENT_PUBLIC_KEY
+                  value: age1gzf883y8p0wfy5yjn5l3l2axnqxdgtw2zdcp8jqsrk65m7gf6y6qzgkf63
+                - name: BUCKET
+                  valueFrom:
+                    configMapKeyRef:
+                      name: etcd-backup
+                      key: BUCKET_NAME
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: etcd-backup
+                      key: AWS_ACCESS_KEY_ID
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: etcd-backup
+                      key: AWS_SECRET_ACCESS_KEY
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  memory: 256Mi
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+                - name: talos
+                  mountPath: /.talos
+                - name: talos-secrets
+                  mountPath: /var/run/secrets/talos.dev
+          volumes:
+            - name: tmp
+              emptyDir: {}
+            - name: talos
+              emptyDir: {}
+            - name: talos-secrets
+              secret:
+                secretName: talos-etcd-backup

--- a/applications/operators/etcd-backup/manifests/kustomization.yaml
+++ b/applications/operators/etcd-backup/manifests/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - talos-serviceaccount.yaml
+  - objectbucketclaim.yaml
+  - cronjob.yaml

--- a/applications/operators/etcd-backup/manifests/namespace.yaml
+++ b/applications/operators/etcd-backup/manifests/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcd-backup
+  labels:
+    managed-by: argocd

--- a/applications/operators/etcd-backup/manifests/objectbucketclaim.yaml
+++ b/applications/operators/etcd-backup/manifests/objectbucketclaim.yaml
@@ -1,0 +1,13 @@
+# Provisions an S3 bucket on the Ceph object store (RGW). Rook creates a
+# ConfigMap and Secret named "etcd-backup" in this namespace holding the
+# bucket name and access keys, which the CronJob consumes. The bucket lives
+# on the Ceph OSDs (Proxmox tier) — a different failure domain from the
+# single Hetzner control plane.
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: etcd-backup
+  namespace: etcd-backup
+spec:
+  generateBucketName: etcd-backup
+  storageClassName: ceph-bucket

--- a/applications/operators/etcd-backup/manifests/talos-serviceaccount.yaml
+++ b/applications/operators/etcd-backup/manifests/talos-serviceaccount.yaml
@@ -1,0 +1,12 @@
+# Talos-issued credentials for etcd snapshots, scoped to os:etcd:backup.
+# The controller materialises a Secret of the same name (ca.crt/crt/key),
+# which the CronJob mounts at /var/run/secrets/talos.dev. Requires
+# machine.features.kubernetesTalosAPIAccess on the control plane (Terraform).
+apiVersion: talos.dev/v1alpha1
+kind: ServiceAccount
+metadata:
+  name: talos-etcd-backup
+  namespace: etcd-backup
+spec:
+  roles:
+    - os:etcd:backup

--- a/applications/operators/kustomization.yaml
+++ b/applications/operators/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - cnpg-operator
   - metrics-server
   - cluster-autoscaler
+  - etcd-backup

--- a/terragrunt/cluster/talos/main.tf
+++ b/terragrunt/cluster/talos/main.tf
@@ -98,6 +98,17 @@ data "talos_machine_configuration" "control_plane" {
         nodeLabels = {
           "storage.longhorn.io/eligible" = "true"
         }
+        # Let a pod in the etcd-backup namespace call the Talos API for etcd
+        # snapshots, scoped to the os:etcd:backup role only. Consumed by the
+        # talos-backup CronJob (applications/operators/etcd-backup). Applied
+        # in place, no reboot.
+        features = {
+          kubernetesTalosAPIAccess = {
+            enabled                     = true
+            allowedRoles                = ["os:etcd:backup"]
+            allowedKubernetesNamespaces = ["etcd-backup"]
+          }
+        }
       }
     }),
   ]

--- a/terragrunt/cluster/terragrunt.hcl
+++ b/terragrunt/cluster/terragrunt.hcl
@@ -38,15 +38,15 @@ inputs = {
   authentik_secret_key = include.env.locals.secrets.authentik_secret_key
   argocd_age_key       = include.env.locals.argocd_age_key
 
+  # Single control plane, sized up so it can also carry workloads. One etcd
+  # member means no quorum/HA: a CP outage stops the API (workloads keep
+  # running on the workers) and losing the node requires an etcd snapshot
+  # restore, so etcd backups are mandatory. Scaling a *live* 3-member etcd
+  # down to 1 must be done one member at a time (destroying two at once loses
+  # quorum); on a disposable POC, rebuild instead.
   control_plane_nodes = {
     controlplane-1 = {
-      server_type = "cx23"
-    }
-    controlplane-2 = {
-      server_type = "cx23"
-    }
-    controlplane-3 = {
-      server_type = "cx23"
+      server_type = "cx33"
     }
   }
 


### PR DESCRIPTION
Collapses the control plane from 3× `cx23` to a single `cx33` on Hetzner, and adds an off-node etcd backup — mandatory once there's no etcd quorum to fall back on.

## Changes

- **Collapse to one control plane** (`terragrunt/cluster/terragrunt.hcl`): 3× `cx23` → 1× `cx33`. `cx43` was chosen first but is out of stock in both German locations; `cx33` is still a step up. Sized so it can also carry workloads (scheduling on control planes is already enabled).
- **Scheduled etcd snapshots** (`applications/operators/etcd-backup/` + `terragrunt/cluster/talos/main.tf`): `siderolabs/talos-backup` as a 6-hourly CronJob. It snapshots etcd via the Talos API, age-encrypts, and pushes to an S3 bucket on the **Ceph object store (RGW)**.
  - Auth: a `talos.dev` ServiceAccount scoped to `os:etcd:backup`, backed by a new `machine.features.kubernetesTalosAPIAccess` block on the control plane (applied in place, no reboot), gated to the `etcd-backup` namespace.
  - Storage: an `ObjectBucketClaim` (`ceph-bucket`) provisions the bucket + credentials. It lives on the Ceph OSDs on the **Proxmox** tier — a different failure domain from the Hetzner CP, so losing the CP node doesn't lose its backups.
  - Encryption: snapshots are age-encrypted to the YubiKey identity from `.sops.yaml` by default.
- **Repo tooling** (`.claude/settings.json`): `includeCoAuthoredBy: false`.

## Why single-node is acceptable here

A single etcd member always has quorum (majority of 1) but tolerates zero failures: a CP reboot (upgrade/kernel) is a brief API outage, and node/disk loss requires an etcd snapshot restore. Workloads on the workers keep serving throughout — hence the backup being the load-bearing mitigation. Ingress and the API endpoint are single-door regardless of CP count, so control-plane HA wasn't buying end-to-end uptime anyway.

## ⚠️ Applying the 3→1 reduction safely

Terraform will **destroy** the two removed control-plane VMs. A raw VM destroy does *not* remove the node from etcd, so dropping two members at once puts the survivor below quorum (needs 2 of 3) and etcd goes read-only. Do it one member at a time:

1. Remove one CP from `control_plane_nodes`, `terragrunt apply`, and gracefully leave etcd for the destroyed node (`talosctl -n <ip> reset --graceful`, or `talosctl etcd remove-member`). Confirm `talosctl etcd members` shrinks and stays healthy.
2. Repeat for the second. Never drop two at once.

(Or, if state is disposable, rebuild — but a full destroy also takes the workers and Ceph OSDs, so it's not a control-plane-only operation.)

## Follow-ups before the backup is live

- Apply the Terraform change first so `kubernetesTalosAPIAccess` (and the `serviceaccounts.talos.dev` CRD) exist.
- Pin the `talos-backup` image — `manifests/cronjob.yaml` uses `:latest`; replace with a released tag from `ghcr.io/siderolabs/talos-backup`.
- Confirm the age recipient is a key you hold offline.
- Optional: replicate the bucket off-site for total-cluster-loss coverage (the in-cluster bucket covers CP-node/disk loss and etcd corruption).

Restore procedure and details in `applications/operators/etcd-backup/README.md`.